### PR TITLE
Support custom js on preview sites

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "prestart": "npm run clean && open-cli http://localhost:3000",
     "clean": "rimraf public",
     "install:hugo": "curl -L -O https://github.com/gohugoio/hugo/releases/download/v0.55.6/hugo_0.55.6_Linux-64bit.tar.gz && tar -xzf hugo_0.55.6_Linux-64bit.tar.gz",
-    "build": "npm run install:hugo && ./hugo --minify"
+    "build": "npm run install:hugo && ./hugo --minify -b \"https://$NOW_URL\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Otherwise, the `main.js` link will point to the main website and fail.