### PR TITLE
Fix JS not loading on non-preview domains

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -74,6 +74,6 @@
 
     {{ $js := resources.Get "js/main.js" }}
     {{ $secureJS := $js | resources.Fingerprint "sha512" }}
-    <script type="text/javascript" src="{{ $secureJS.Permalink }}" integrity="{{ $secureJS.Data.Integrity }}"></script>
+    <script type="text/javascript" src="{{ $secureJS.RelPermalink }}" integrity="{{ $secureJS.Data.Integrity }}"></script>
   </body>
 </html>


### PR DESCRIPTION
JS wasn't loading because it bakes in the deployment URL, which on production doesn't match up with the deployment URL because it's a passthrough of vickyhughes.co.uk

Before:

```html
<script type="text/javascript" src="https://vickyhughescouk-e9tcxpx15.now.sh/js/main.d7a7150c7d9efa94e8f28cb0e99dd58b0026ad3db20ad56173a1c666a4ca58f1294c59f8bc32953e962f54fc498f53b49fb52bd3da135e006cf3a3e5a0449e1f.js" integrity="sha512-16cVDH2e+pTo8oyw6Z3ViwAmrT2yCtVhc6HGZqTKWPEpTFn4vDKVPpYvVPxJj1O0n7Ur09oTXgBs86PloESeHw=="></script>
```

After:

```html
<script type="text/javascript" src="/js/main.d7a7150c7d9efa94e8f28cb0e99dd58b0026ad3db20ad56173a1c666a4ca58f1294c59f8bc32953e962f54fc498f53b49fb52bd3da135e006cf3a3e5a0449e1f.js" integrity="sha512-16cVDH2e+pTo8oyw6Z3ViwAmrT2yCtVhc6HGZqTKWPEpTFn4vDKVPpYvVPxJj1O0n7Ur09oTXgBs86PloESeHw=="></script>
```