### PR TITLE
Add tags to page layouts and new tag filter page

### DIFF
--- a/content/portfolio/funwithfaces/index.md
+++ b/content/portfolio/funwithfaces/index.md
@@ -2,6 +2,9 @@
 title: "Fun with faces challenge"
 date: 2020-03-11
 image: IMG_20200312_155121_241.jpg
+tags:
+  - Characters
+  - Personal work
 ---
 ![Power woman](IMG_20200312_155121_241.jpg)
 

--- a/content/portfolio/mood-ambientmusic/index.md
+++ b/content/portfolio/mood-ambientmusic/index.md
@@ -2,6 +2,8 @@
 title: "The Therapuetic Power of Ambient Music"
 date: 2020-03-09
 image: IMG_1176.jpg
+tags:
+  - Editorial
 ---
 
 ![Therapuetic power of ambient music](IMG_1176.jpg)

--- a/content/portfolio/mood-loveletter/index.md
+++ b/content/portfolio/mood-loveletter/index.md
@@ -6,4 +6,4 @@ image: IMG_1186.jpg
 
 ![Time to revive the love letter](IMG_1186.jpg)
 
-An editorial illustration for the lovely people at [MOOD mag](https://www.itsmoodmag.com/).
+An editorial illustration for the lovely people at [MOOD mag](https://www.itsmoodmag.com/). 

--- a/content/portfolio/mood-perfecthuman/index.md
+++ b/content/portfolio/mood-perfecthuman/index.md
@@ -2,6 +2,8 @@
 title: "Becoming the Perfect Human"
 date: 2020-03-09
 image: IMG_1190.jpg
+tags:
+  - Editorial
 ---
 
 ![Becoming the perfect human](IMG_1190.jpg)

--- a/content/portfolio/quiet/index.md
+++ b/content/portfolio/quiet/index.md
@@ -2,12 +2,13 @@
 title: "Quiet"
 date: 2020-04-06
 image: IMG_1445.jpg
+tags:
+  - Personal
 ---
-A few friends and I started a drawing club during lockdown. Our theme for this week was Quiet: here's my response to it, and some sketches. 
+
+A few friends and I started a drawing club during lockdown. Our theme for this week was Quiet: here's my response to it, and some sketches.
 ![Quiet](IMG_1445.jpg)
 
 ![Quiet sketch 1](IMG_20200406_161429.jpg)
 
 ![Quiet sketch 2](IMG_20200406_161421.jpg)
-
-

--- a/content/portfolio/quiet/index.md
+++ b/content/portfolio/quiet/index.md
@@ -3,7 +3,7 @@ title: "Quiet"
 date: 2020-04-06
 image: IMG_1445.jpg
 tags:
-  - Personal
+  - Personal work
 ---
 
 A few friends and I started a drawing club during lockdown. Our theme for this week was Quiet: here's my response to it, and some sketches.

--- a/content/portfolio/still-here-still-life/index.md
+++ b/content/portfolio/still-here-still-life/index.md
@@ -2,6 +2,8 @@
 title: "Still here still life"
 date: 2020-04-08
 image: IMG_20200408_170032_493.jpg
+tags:
+  - Personal work
 ---
 
 A still life drawing club, which is helping me relax during lockdown. You can find out more on their Instagram [here](https://www.instagram.com/stillherestilllife/).

--- a/content/portfolio/time-alone-with-your-thoughts/index.md
+++ b/content/portfolio/time-alone-with-your-thoughts/index.md
@@ -2,6 +2,8 @@
 title: "Spend some time alone with your thoughts"
 date: 2020-04-01
 image: IMG_1403.jpg
+tags:
+  - Personal work
 ---
 
 My response to It's Nice That's weekly brief, which was "a fun activity you can do by yourself". Mine is "spend some time alone with your thoughts", and a few familiar characters from previous projects crop up.

--- a/content/portfolio/travel/index.md
+++ b/content/portfolio/travel/index.md
@@ -2,6 +2,8 @@
 title: "Travel"
 date: 2020-04-23
 image: IMG_1501.JPG
+tags:
+  - Personal work
 ---
 
 A personal illustration to experiment with characters. Concepts for travel-themed characters were crowd sourced from friends and family!

--- a/css/main.css
+++ b/css/main.css
@@ -94,6 +94,10 @@ nav a.active {
   margin: auto;
 }
 
+h2.tagTitle {
+  padding: 1rem;
+}
+
 ul.grid {
   padding: 0;
   width: 100%;

--- a/css/main.css
+++ b/css/main.css
@@ -158,6 +158,10 @@ ul.grid h3 {
   }
 }
 
+article h2 {
+  margin-bottom: 0;
+}
+
 article img {
   object-fit: cover;
   max-width: 100%;
@@ -166,7 +170,7 @@ article img {
   margin: 2rem auto;
 }
 article div {
-  padding: 2em 0;
+  padding-bottom: 2em;
 }
 article a {
   border-bottom: 2px solid var(--theme);
@@ -174,6 +178,11 @@ article a {
 article time {
   display: block;
   opacity: 0.5;
+}
+
+article .tags {
+  margin-top: 0.33em;
+  font-size: 90%;
 }
 
 footer {

--- a/layouts/partials/tags.html
+++ b/layouts/partials/tags.html
@@ -1,0 +1,8 @@
+{{ with .Param "tags" }}
+{{ $last := sub (len .) 1 }}
+  <p class="tags">
+    {{ range $index, $tag := . -}}
+      <a href="/tags/{{ $tag | urlize }}/">{{ $tag }}</a>{{- if lt $index $last }},&nbsp;{{end}}
+    {{- end -}}
+  </p>
+{{ end }}

--- a/layouts/portfolio/single.html
+++ b/layouts/portfolio/single.html
@@ -3,7 +3,7 @@
 {{ define "main" }}
 <article class="porfolio mid-width">
   <h2>{{ .Title }}</h2>
-  <time>{{ .Date.Format "January 02, 2006" }}</time>
+  {{ partial "tags.html" . }}
   <div>{{ .Content }}</div>
 </article>
 {{ end }}

--- a/layouts/taxonomy/tag.html
+++ b/layouts/taxonomy/tag.html
@@ -1,7 +1,7 @@
 {{ define "title" }}{{ .Title }} &ndash; {{ .Site.Title }}{{ end }}
 
 {{ define "main" }}
-  <h2>Tag: {{ .Title }}</h2>
+  <h2 class="tagTitle">{{ .Title }}</h2>
   <ul class="grid">
     {{ range .Data.Pages }}
       {{ $featured := .Params.image}}

--- a/layouts/taxonomy/tag.html
+++ b/layouts/taxonomy/tag.html
@@ -1,0 +1,22 @@
+{{ define "title" }}{{ .Title }} &ndash; {{ .Site.Title }}{{ end }}
+
+{{ define "main" }}
+  <h2>Tag: {{ .Title }}</h2>
+  <ul class="grid">
+    {{ range .Data.Pages }}
+      {{ $featured := .Params.image}}
+      <li>
+        <a href="{{ .RelPermalink}} ">
+          <div class="Image">
+          {{ range .Resources.ByType "image" }}
+            {{ if eq .Name $featured }}
+              {{ $image := .Resize "x900" }}
+              <img src="{{ $image.RelPermalink }}">
+            {{ end }}
+          {{ end }}
+          </div>
+        </a>
+      </li>
+    {{ end }}
+  </ul>
+{{ end }}


### PR DESCRIPTION
Tags link to a "tag taxonomy" page where you can see all the pages with the matching tag. Same template as homepage

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/9041370/81722862-ec062200-9479-11ea-8edf-7e45f66f3b03.png">

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/9041370/81722886-f3c5c680-9479-11ea-88c4-8e782bcda554.png">
