### PR TITLE
Fix missing titles on About and Contact

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -1,8 +1,7 @@
 ---
-title: " "
+title: "About"
 type: "about"
 ---
-
 
 I'm a freelance illustrator, currently studying for a Graduate Diploma in Illustration at Camberwell College of Arts.
 
@@ -11,4 +10,3 @@ Until recently I had a very sensible job as a data scientist; first in the Civil
 I love drawing fun and playful characters, and I'm interested in escapism, the mind and emotional intelligence. I've illustrated for tech startups, childrens' books and online magazines. At the moment I'm particularly seeking editorial work.
 
 If you'd like to work together, please [get in touch](mailto:vicky.hughes@hotmail.com)!
-

--- a/content/contact.md
+++ b/content/contact.md
@@ -1,5 +1,5 @@
 ---
-title: ""
+title: "Contact"
 type: "contact"
 ---
 


### PR DESCRIPTION
Looks like the titles were set to ""