### PR TITLE
Remove image resizer on tag page to fix missing gif animations

### DIFF
--- a/layouts/taxonomy/tag.html
+++ b/layouts/taxonomy/tag.html
@@ -10,8 +10,7 @@
           <div class="Image">
           {{ range .Resources.ByType "image" }}
             {{ if eq .Name $featured }}
-              {{ $image := .Resize "x900" }}
-              <img src="{{ $image.RelPermalink }}">
+              <img src="{{ .RelPermalink }}">
             {{ end }}
           {{ end }}
           </div>


### PR DESCRIPTION
We were resizing to 900px to save page weight, which was removing the animations as the resizer doesn't consider the multiple frames of GIFs