### PR TITLE
Fix custom URL dropping on left/right navigation

### DIFF
--- a/layouts/partials/titlesection.html
+++ b/layouts/partials/titlesection.html
@@ -1,7 +1,7 @@
 <div class="titlesection">
     <div class="next-post">
         {{ if .NextInSection }}
-        <a href="{{ .NextInSection.Permalink }}">←</a>
+        <a href="{{ .NextInSection.RelPermalink }}">←</a>
         {{ end }}
     </div>
 
@@ -11,7 +11,7 @@
 
     <div class="previous-post">
         {{ if .PrevInSection }}
-        <a href="{{ .PrevInSection.Permalink }}">→</a>
+        <a href="{{ .PrevInSection.RelPermalink }}">→</a>
         {{ end }}
     </div>
 </div>


### PR DESCRIPTION
We were using the Permalink, which embeds the build URL into the link. Relpermalink navigates relative to the current page.